### PR TITLE
Handle 1MB+ record as exception

### DIFF
--- a/target_kinesis/firehose.py
+++ b/target_kinesis/firehose.py
@@ -1,6 +1,9 @@
 import boto3
 import json
 import singer
+from botocore.exceptions import ClientError
+
+logger = singer.get_logger()
 
 
 def firehose_setup_client(config):
@@ -26,8 +29,11 @@ def firehose_deliver(client, stream_name, records):
     encoded_records = map(lambda x: json.dumps(x), records)
     payload = ("\n".join(encoded_records) + "\n")
 
-    response = client.put_record(
-        DeliveryStreamName=stream_name,
-        Record={'Data': payload}
-    )
-    return response
+    try:
+        response = client.put_record(
+            DeliveryStreamName=stream_name,
+            Record={'Data': payload}
+        )
+        return response
+    except ClientError as c:
+        logger.debug("Error: {}".format(c.message))

--- a/target_kinesis/firehose.py
+++ b/target_kinesis/firehose.py
@@ -36,4 +36,4 @@ def firehose_deliver(client, stream_name, records):
         )
         return response
     except ClientError as c:
-        logger.debug("Error: {}".format(c.message))
+        logger.error(c.response['Error']['Message'])

--- a/target_kinesis/kinesis.py
+++ b/target_kinesis/kinesis.py
@@ -38,4 +38,4 @@ def kinesis_deliver(client, stream_name, partition_key, records):
         )
         return response
     except ClientError as c:
-        logger.debug("Error: {}".format(c.message))
+        logger.error(c.response['Error']['Message'])


### PR DESCRIPTION
Closes #11 

### Implementation details

`ClientError` generated as a response for big records are handled as an exception. The record is discarded but doesn't stop the stream.
